### PR TITLE
Remove extra space in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Google Cloud Platform 上でPleromaを簡単に構築できるスタートアッ
 このリポジトリを clone します
 
 ```
-git clone https://github.com/S-H-GAMELINKS/Pleroma.Start.Script.for.GoogleCloudPlatform.git　pleroma
+git clone https://github.com/S-H-GAMELINKS/Pleroma.Start.Script.for.GoogleCloudPlatform.git pleroma
 ```
 
 clone したら、ディレクトリを移動し、


### PR DESCRIPTION
Copying the git clone script causes error because there is an extra
space. 

Other than that, the script works great. Thank you for making pleroma easy to
install ^_^